### PR TITLE
Sprint 2 Phase 2

### DIFF
--- a/src/cli/charm/create.rs
+++ b/src/cli/charm/create.rs
@@ -134,7 +134,7 @@ impl<'a> CliCommand<'a> for CreateSubcommand {
             if !args.is_present("charm_name") {
                 template_settings.charm_name = template_settings
                     .charm_display_name
-                    .replace(" ", "_")
+                    .replace(" ", "-")
                     .to_lowercase();
             }
 
@@ -159,7 +159,7 @@ impl<'a> CliCommand<'a> for CreateSubcommand {
             if !args.is_present("charm_name") {
                 let default = &template_settings
                     .charm_display_name
-                    .replace(" ", "_")
+                    .replace(" ", "-")
                     .to_lowercase();
                 let response = prompt_reply_stdout(&format!("Charm name [{}]: ", default))
                     .context("Could not prompt for charm name")?;

--- a/src/daemon/types.rs
+++ b/src/daemon/types.rs
@@ -14,6 +14,10 @@ use std::ops::Deref;
 /// version and will return `true` if the clone and the original are the same. This means that if
 /// you modify the type and the set it back to what it was previously, `is_clean()` will still
 /// return `true`.
+/// 
+/// > **Note:** Newly created `Cd`'s start off "dirty" and `is_clean()` will return false. You
+/// > can also force any `Cd` to register as dirty, regardless of whether or not the inner type has
+/// > changed by running `mark_dirty()`.
 ///
 /// The inner type is required to implement `Clone` and `PartialEq`.
 pub(crate) struct Cd<T: Clone + PartialEq> {
@@ -31,7 +35,8 @@ impl<T: Clone + PartialEq> Cd<T> {
         Cd {
             inner,
             new_inner: None,
-            force_dirty: false,
+            // New change detectors start off "dirty"
+            force_dirty: true,
         }
     }
 


### PR DESCRIPTION
- Fix containers not starting when just the image has been set: The internal change detection type was not marking newly created containers a "changed".
- Make sure `lucky charm create` fills in the charm name with dashes instead of underscores.